### PR TITLE
Implement default address loading during cart step

### DIFF
--- a/checkout/lib/market_town/checkout/integrations/spree.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree.rb
@@ -8,5 +8,6 @@ module MarketTown
 end
 
 require 'market_town/checkout/integrations/spree/order'
+require 'market_town/checkout/integrations/spree/address_storage'
 require 'market_town/checkout/integrations/spree/finish'
 require 'market_town/checkout/integrations/spree/container'

--- a/checkout/lib/market_town/checkout/integrations/spree/address_storage.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree/address_storage.rb
@@ -1,0 +1,15 @@
+module MarketTown
+  module Checkout
+    module Spree
+      class AddressStorage
+        def load_default(state)
+          if state[:order].user_id?
+            state[:order].bill_address = state[:order].user.bill_address.try(:clone)
+            state[:order].ship_address = state[:order].user.ship_address.try(:clone)
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/checkout/lib/market_town/checkout/integrations/spree/container.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree/container.rb
@@ -6,6 +6,10 @@ module MarketTown
           Order.new
         end
 
+        def address_storage
+          AddressStorage.new
+        end
+
         def finish
           Finish.new
         end

--- a/checkout/spec/checkout/integrations/spree_like/cart_step.rb
+++ b/checkout/spec/checkout/integrations/spree_like/cart_step.rb
@@ -14,6 +14,31 @@ module MarketTown::Checkout
         end
       end
 
+      context 'and the customer has a saved address' do
+        let(:customer_address) { create(:address) }
+
+        let(:user) { create(:user, bill_address: customer_address,
+                                   ship_address: customer_address) }
+
+        before(:each) do
+          CartStep.new(deps).process(order: order)
+        end
+
+        context 'to an order that already has addresses associated' do
+          let(:order) { create(:order_with_totals, user: user) }
+          subject { order.billing_address }
+          it { is_expected.to eq(customer_address) }
+        end
+
+        context 'to an order that does not have addresses associated' do
+          let(:order) { create(:order_with_totals, user: user,
+                        bill_address: nil,
+                        ship_address: nil) }
+          subject { order.billing_address }
+          it { is_expected.to eq(customer_address) }
+        end
+      end
+
       context 'and the order does not have line items' do
         let(:order) { create(:order) }
 


### PR DESCRIPTION
Unlike spree and solidus implementations, calling AddressStorage#load_default will always overwrite existing billing and shipping addresses on an order.