### PR TITLE
Remove AddressStep#ensure_delivery

### DIFF
--- a/checkout/lib/market_town/checkout/contracts/fulfilments.rb
+++ b/checkout/lib/market_town/checkout/contracts/fulfilments.rb
@@ -2,10 +2,6 @@ module MarketTown
   module Checkout
     module Contracts
       class Fulfilments
-        def can_fulfil_address?(state)
-          true
-        end
-
         def propose_shipments(state)
         end
 
@@ -20,11 +16,6 @@ module MarketTown
         end
 
         shared_examples_for 'Fulfilments' do
-          context '#can_fulfil_address?' do
-            subject { described_class.new.can_fulfil_address?({}) }
-            it_behaves_like 'a boolean query method'
-          end
-
           context '#can_fulfil_shipments?' do
             subject { described_class.new.can_fulfil_shipments?({}) }
             it_behaves_like 'a boolean query method'

--- a/checkout/lib/market_town/checkout/steps/address_step.rb
+++ b/checkout/lib/market_town/checkout/steps/address_step.rb
@@ -4,7 +4,6 @@ module MarketTown
     #
     # Dependencies:
     #
-    # - {Contracts::Fulfilments#can_fulfil_address?}
     # - {Contracts::UserAddressStorage#store_billing_address}
     # - {Contracts::UserAddressStorage#store_delivery_address}
     # - {Contracts::Fulfilments#propose_shipments}
@@ -17,7 +16,6 @@ module MarketTown
       steps :validate_billing_address,
             :use_billing_address_as_delivery_address,
             :validate_delivery_address,
-            :ensure_delivery,
             :store_user_addresses,
             :propose_shipments,
             :finish_address_step
@@ -42,18 +40,6 @@ module MarketTown
       #
       def validate_delivery_address(state)
         validate_address(:delivery, state[:delivery_address])
-      end
-
-      # Tries to ensure delivery can be made to address
-      #
-      # @raise [CannotFulfilAddressError]
-      #
-      def ensure_delivery(state)
-        unless deps.fulfilments.can_fulfil_address?(state)
-          raise CannotFulfilAddressError.new(state[:delivery_address])
-        end
-      rescue MissingDependency
-        add_dependency_missing_warning(state, :cannot_ensure_delivery)
       end
 
       # Tries to store user addresses

--- a/checkout/spec/checkout/steps/address_step_spec.rb
+++ b/checkout/spec/checkout/steps/address_step_spec.rb
@@ -26,12 +26,6 @@ module MarketTown::Checkout
         end
 
         it { is_expected.to include(:billing_address, :delivery_address) }
-
-        context 'and cannot fulfil delivery address' do
-          let(:fulfilments) { double(can_fulfil_address?: false) }
-
-          it { expect { subject }.to raise_error(AddressStep::CannotFulfilAddressError) }
-        end
       end
 
       context 'with empty billing address' do


### PR DESCRIPTION
This isn’t provided by Spree or Solidus so no need to provide this step. We can add it back in future if we think its valuable.