### PR TITLE
Move AddressStep#propose_shipments to DeliveryStep

### DIFF
--- a/checkout/lib/market_town/checkout/contracts/fulfilments.rb
+++ b/checkout/lib/market_town/checkout/contracts/fulfilments.rb
@@ -2,10 +2,6 @@ module MarketTown
   module Checkout
     module Contracts
       class Fulfilments
-        def can_fulfil_address?(state)
-          true
-        end
-
         def propose_shipments(state)
         end
 
@@ -20,11 +16,6 @@ module MarketTown
         end
 
         shared_examples_for 'Fulfilments' do
-          context '#can_fulfil_address?' do
-            subject { described_class.new.can_fulfil_address?({}) }
-            it_behaves_like 'a boolean query method'
-          end
-
           context '#can_fulfil_shipments?' do
             subject { described_class.new.can_fulfil_shipments?({}) }
             it_behaves_like 'a boolean query method'

--- a/checkout/lib/market_town/checkout/contracts/fulfilments.rb
+++ b/checkout/lib/market_town/checkout/contracts/fulfilments.rb
@@ -16,14 +16,14 @@ module MarketTown
         end
 
         shared_examples_for 'Fulfilments' do
-          context '#can_fulfil_shipments?' do
-            subject { described_class.new.can_fulfil_shipments?({}) }
-            it_behaves_like 'a boolean query method'
-          end
-
           context '#propose_shipments' do
             subject { described_class.new.propose_shipments({}) }
             it_behaves_like 'a command method'
+          end
+
+          context '#can_fulfil_shipments?' do
+            subject { described_class.new.can_fulfil_shipments?({}) }
+            it_behaves_like 'a boolean query method'
           end
 
           context '#apply_shipment_costs' do

--- a/checkout/lib/market_town/checkout/steps/address_step.rb
+++ b/checkout/lib/market_town/checkout/steps/address_step.rb
@@ -6,7 +6,6 @@ module MarketTown
     #
     # - {Contracts::UserAddressStorage#store_billing_address}
     # - {Contracts::UserAddressStorage#store_delivery_address}
-    # - {Contracts::Fulfilments#propose_shipments}
     # - {Contracts::Finish#address_step}
     #
     class AddressStep < Step
@@ -17,7 +16,6 @@ module MarketTown
             :use_billing_address_as_delivery_address,
             :validate_delivery_address,
             :store_user_addresses,
-            :propose_shipments,
             :finish_address_step
 
       protected
@@ -54,15 +52,6 @@ module MarketTown
         end
       rescue MissingDependency
         add_dependency_missing_warning(state, :cannot_store_user_addresses)
-      end
-
-      # Tries to proposes shipments to delivery address ready to be confirmed at
-      # delivery step.
-      #
-      def propose_shipments(state)
-        deps.fulfilments.propose_shipments(state)
-      rescue MissingDependency
-        add_dependency_missing_warning(state, :cannot_propose_shipments)
       end
 
       # Finishes address step

--- a/checkout/lib/market_town/checkout/steps/address_step.rb
+++ b/checkout/lib/market_town/checkout/steps/address_step.rb
@@ -4,7 +4,6 @@ module MarketTown
     #
     # Dependencies:
     #
-    # - {Contracts::Fulfilments#can_fulfil_address?}
     # - {Contracts::UserAddressStorage#store_billing_address}
     # - {Contracts::UserAddressStorage#store_delivery_address}
     # - {Contracts::Fulfilments#propose_shipments}
@@ -17,7 +16,6 @@ module MarketTown
       steps :validate_billing_address,
             :use_billing_address_as_delivery_address,
             :validate_delivery_address,
-            :ensure_delivery,
             :store_user_addresses,
             :propose_shipments,
             :finish_address_step
@@ -42,18 +40,6 @@ module MarketTown
       #
       def validate_delivery_address(state)
         validate_address(:delivery, state[:delivery_address])
-      end
-
-      # Tries to ensure delivery can be made to address
-      #
-      # @raise [CannotFulfilAddressError]
-      #
-      def ensure_delivery(state)
-        unless deps.fulfilments.can_fulfil_address?(state)
-          raise CannotFulfilAddressError.new(state[:delivery_address])
-        end
-      rescue MissingDependency
-        add_dependency_missing_warning(state, :cannot_ensure_delivery)
       end
 
       # Tries to store user addresses

--- a/checkout/lib/market_town/checkout/steps/delivery_step.rb
+++ b/checkout/lib/market_town/checkout/steps/delivery_step.rb
@@ -4,6 +4,7 @@ module MarketTown
     #
     # Dependencies:
     #
+    # - {Contracts::Fulfilments#propose_shipments}
     # - {Contracts::Fulfilments#can_fulfil_shipments?}
     # - {Contracts::Promotions#apply_delivery_promotions}
     # - {Contracts::Finish#delivery_step}
@@ -13,6 +14,7 @@ module MarketTown
       class CannotFulfilShipmentsError < Error; end
 
       steps :validate_delivery_address,
+            :propose_shipments,
             :validate_shipments,
             :apply_delivery_promotions,
             :load_default_payment_method,
@@ -26,6 +28,15 @@ module MarketTown
         Address.validate!(state[:delivery_address])
       rescue Address::InvalidError => e
         raise InvalidDeliveryAddressError.new(e.data)
+      end
+
+      # Tries to proposes shipments to delivery address ready to be confirmed at
+      # delivery step.
+      #
+      def propose_shipments(state)
+        deps.fulfilments.propose_shipments(state)
+      rescue MissingDependency
+        add_dependency_missing_warning(state, :cannot_propose_shipments)
       end
 
       # Tries to validate shipments

--- a/checkout/spec/checkout/steps/address_step_spec.rb
+++ b/checkout/spec/checkout/steps/address_step_spec.rb
@@ -26,12 +26,6 @@ module MarketTown::Checkout
         end
 
         it { is_expected.to include(:billing_address, :delivery_address) }
-
-        context 'and cannot fulfil delivery address' do
-          let(:fulfilments) { double(can_fulfil_address?: false) }
-
-          it { expect { subject }.to raise_error(AddressStep::CannotFulfilAddressError) }
-        end
       end
 
       context 'with empty billing address' do

--- a/checkout/spec/checkout/steps/address_step_spec.rb
+++ b/checkout/spec/checkout/steps/address_step_spec.rb
@@ -1,7 +1,5 @@
 module MarketTown::Checkout
   describe AddressStep do
-    let(:fulfilments) { double(can_fulfil_address?: true, propose_shipments: nil) }
-
     let(:user_address_storage) do
       double(store_billing_address: nil,
              store_delivery_address: nil)
@@ -10,8 +8,7 @@ module MarketTown::Checkout
     let(:finish) { double(address_step: nil) }
 
     let(:deps) do
-      Dependencies.new(fulfilments: fulfilments,
-                       user_address_storage: user_address_storage,
+      Dependencies.new(user_address_storage: user_address_storage,
                        finish: finish,
                        logger: double(warn: nil))
     end
@@ -79,32 +76,6 @@ module MarketTown::Checkout
 
         it { is_expected.to have_received(:store_billing_address) }
         it { is_expected.to have_received(:store_delivery_address) }
-      end
-    end
-
-    context 'when proposing shipments' do
-      subject do
-        step.process(billing_address: mock_address,
-                     delivery_address: mock_address)
-      end
-
-      it { is_expected.to include(:billing_address, :delivery_address) }
-
-      context 'then fulfilments' do
-        before do
-          step.process(billing_address: mock_address,
-                       delivery_address: mock_address)
-        end
-
-        subject { fulfilments }
-
-        it { is_expected.to have_received(:propose_shipments) }
-      end
-
-      context 'and no fulfilments' do
-        let(:fulfilments) { nil }
-
-        it { is_expected.to include(:warnings) }
       end
     end
 

--- a/checkout/spec/checkout/steps/delivery_step_spec.rb
+++ b/checkout/spec/checkout/steps/delivery_step_spec.rb
@@ -1,6 +1,6 @@
 module MarketTown::Checkout
   describe DeliveryStep do
-    let(:fulfilments) { double(can_fulfil_shipments?: true) }
+    let(:fulfilments) { double(propose_shipments: nil, can_fulfil_shipments?: true) }
     let(:promotions) { double(apply_delivery_promotions: nil) }
     let(:payments) { double(load_default_payment_method: nil) }
     let(:finish) { double(delivery_step: nil) }
@@ -35,6 +35,32 @@ module MarketTown::Checkout
       end
     end
 
+    context 'when proposing shipments' do
+      subject do
+        step.process(billing_address: mock_address,
+                     delivery_address: mock_address)
+      end
+
+      it { is_expected.to include(:billing_address, :delivery_address) }
+
+      context 'then fulfilments' do
+        before do
+          step.process(billing_address: mock_address,
+                       delivery_address: mock_address)
+        end
+
+        subject { fulfilments }
+
+        it { is_expected.to have_received(:propose_shipments) }
+      end
+
+      context 'and no fulfilments' do
+        let(:fulfilments) { nil }
+
+        it { is_expected.to include(:warnings) }
+      end
+    end
+
     context 'when validating fulfilments' do
       subject { step.process(delivery_address: mock_address) }
 
@@ -55,7 +81,7 @@ module MarketTown::Checkout
       end
 
       context 'and cannot fulfil shipments' do
-        let(:fulfilments) { double(can_fulfil_shipments?: false) }
+        let(:fulfilments) { double(propose_shipments: nil, can_fulfil_shipments?: false) }
 
         it { expect { subject }.to raise_error(DeliveryStep::CannotFulfilShipmentsError) }
       end


### PR DESCRIPTION
We might not need to propose shipments if a checkout does not have a delivery step or does not have physical deliveries.