### PR TITLE
Implement brochure page ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,18 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
+env:
+  - GOPATH=$PWD/gopath
+
 install:
+  - gimme 1.7
+  - mkdir -p $GOPATH/src && cp -r brochure/ $GOPATH/src/brochure/ && pushd $GOPATH/src/brochure && go get -t ./... && popd
   - pushd checkout && BUNDLE_GEMFILE=$PWD/Gemfile bundle install && popd
   - pushd checkout && BUNDLE_GEMFILE=$PWD/Gemfile.solidus.rb bundle install && popd
   - pushd checkout && BUNDLE_GEMFILE=$PWD/Gemfile.spree.rb bundle install && popd
 
 script:
+  - pushd $GOPATH/src/brochure && go test -v && popd
   - pushd checkout && BUNDLE_GEMFILE=$PWD/Gemfile bundle exec rake && popd
 
 notifications:

--- a/brochure/page.go
+++ b/brochure/page.go
@@ -1,0 +1,28 @@
+package brochure
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type pageID struct {
+	Host   string `json:"host"`
+	Path   string `json:"path"`
+	Locale string `json:"locale"`
+	URI    string `json:"uri"`
+}
+
+func PageID(host string, path string, locale string) *pageID {
+	uri := fmt.Sprintf("//%s%s?locale=%s", host, path, locale)
+	return &pageID{host, path, locale, uri}
+}
+
+func PageIDFromURI(uri string) (*pageID, error) {
+	u, err := url.Parse(uri)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &pageID{u.Host, u.Path, u.Query().Get("locale"), uri}, nil
+}

--- a/brochure/page_test.go
+++ b/brochure/page_test.go
@@ -1,0 +1,23 @@
+package brochure
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPageIDBuildsURI(t *testing.T) {
+	pageID := PageID("madetech.com", "/blog/a-blog-post", "en-GB")
+	assert.Equal(t, "//madetech.com/blog/a-blog-post?locale=en-GB", pageID.URI)
+}
+
+func TestPageIDFromURI(t *testing.T) {
+	pageID, _ := PageIDFromURI("//madetech.com/blog/a-blog-post?locale=en-GB")
+	assert.Equal(t, "madetech.com", pageID.Host)
+	assert.Equal(t, "/blog/a-blog-post", pageID.Path)
+	assert.Equal(t, "en-GB", pageID.Locale)
+}
+
+func TestPageIDFromURIReturnsErrorWhenGivenInvalidURI(t *testing.T) {
+	_, err := PageIDFromURI("//%01.com")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This commit introduces the idea of a `brochure.pageID` struct. This struct can be instantiated by one of two methods `PageID()` and `PageIDFromURI()`.

The canonical URI for an indexed page will be in the format of `//madetech.com/blog/a-blog-post?locale=en-GB`. This can be parsed into a Host, Path and Locale. The `brochure.pageID` represents both the parsed form and the URI in it's fields.

We also add testing support for go.