### PR TITLE
Introduce Page, PageRelease and PageContent

### DIFF
--- a/brochure/page.go
+++ b/brochure/page.go
@@ -5,6 +5,12 @@ import (
 	"net/url"
 )
 
+type Page struct {
+	Id       *pageID       `json:"id"`
+	Release  PageRelease   `json:"release"`
+	Contents []PageContent `json:"contents"`
+}
+
 type pageID struct {
 	Host   string `json:"host"`
 	Path   string `json:"path"`
@@ -26,3 +32,10 @@ func PageIDFromURI(uri string) (*pageID, error) {
 
 	return &pageID{u.Host, u.Path, u.Query().Get("locale"), uri}, nil
 }
+
+type PageRelease struct {
+	Timestamp int    `json:"timestamp"`
+	UUID      string `json:"uuid"`
+}
+
+type PageContent map[string]interface{}

--- a/brochure/page_test.go
+++ b/brochure/page_test.go
@@ -1,6 +1,7 @@
 package brochure
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -20,4 +21,28 @@ func TestPageIDFromURI(t *testing.T) {
 func TestPageIDFromURIReturnsErrorWhenGivenInvalidURI(t *testing.T) {
 	_, err := PageIDFromURI("//%01.com")
 	assert.NotNil(t, err)
+}
+
+func TestPageToJSON(t *testing.T) {
+	pageID, _ := PageIDFromURI("//madetech.com/blog/a-blog-post?locale=en-GB")
+
+	page := &Page{
+		Id:       pageID,
+		Release:  PageRelease{100, "f5826bba-4496-4361-a061-e8b76ec0971d"},
+		Contents: []PageContent{},
+	}
+
+	pageJSON := convertPageToJSONString(page)
+	assert.Contains(t, pageJSON, `"host":"madetech.com"`)
+	assert.Contains(t, pageJSON, `"path":"/blog/a-blog-post"`)
+	assert.Contains(t, pageJSON, `"locale":"en-GB"`)
+	assert.Contains(t, pageJSON, `"uri":"//madetech.com/blog/a-blog-post?locale=en-GB"`)
+	assert.Contains(t, pageJSON, `"timestamp":100`)
+	assert.Contains(t, pageJSON, `"uuid":"f5826bba-4496-4361-a061-e8b76ec0971d"`)
+	assert.Contains(t, pageJSON, `"contents":[]`)
+}
+
+func convertPageToJSONString(page *Page) string {
+	pageJSON, _ := json.Marshal(page)
+	return string(pageJSON)
 }


### PR DESCRIPTION
In this change we introduce `Page`, `PageRelease` and `PageContent` types.

`Page` represents a single translation of a page that is indexable. It has three fields: a `pageID` introduced in #14, a `PageRelease` and `[]PageContent`.

We test to ensure the JSON transformation of an example `Page` is as expected.