### PR TITLE
Implement IndexPageRequest()

### DIFF
--- a/brochure/page.go
+++ b/brochure/page.go
@@ -1,6 +1,7 @@
 package brochure
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 )
@@ -16,6 +17,25 @@ type pageID struct {
 	Path   string `json:"path"`
 	Locale string `json:"locale"`
 	URI    string `json:"uri"`
+}
+
+func (pageID *pageID) UnmarshalJSON(data []byte) error {
+	var pageIDFromJSON map[string]string
+	err := json.Unmarshal(data, &pageIDFromJSON)
+	if err != nil {
+		return err
+	}
+
+	newPageID, err := PageIDFromURI(pageIDFromJSON["uri"])
+	if err != nil {
+		return err
+	}
+
+	pageID.Host = newPageID.Host
+	pageID.Path = newPageID.Path
+	pageID.Locale = newPageID.Locale
+	pageID.URI = newPageID.URI
+	return nil
 }
 
 func PageID(host string, path string, locale string) *pageID {

--- a/brochure/page.go
+++ b/brochure/page.go
@@ -7,16 +7,16 @@ import (
 )
 
 type Page struct {
-	Id       *pageID       `json:"id"`
-	Release  PageRelease   `json:"release"`
-	Contents []PageContent `json:"contents"`
+	Id       *pageID       `json:"id"       valid:"required"`
+	Release  PageRelease   `json:"release"  valid:"required"`
+	Contents []PageContent `json:"contents" valid:"optional"`
 }
 
 type pageID struct {
-	Host   string `json:"host"`
-	Path   string `json:"path"`
-	Locale string `json:"locale"`
-	URI    string `json:"uri"`
+	Host   string `json:"host"    valid:"required,host"`
+	Path   string `json:"path"    valid:"required"`
+	Locale string `json:"locale"  valid:"required"`
+	URI    string `json:"uri"     valid:"required"`
 }
 
 func (pageID *pageID) UnmarshalJSON(data []byte) error {
@@ -54,8 +54,8 @@ func PageIDFromURI(uri string) (*pageID, error) {
 }
 
 type PageRelease struct {
-	Timestamp int    `json:"timestamp"`
-	UUID      string `json:"uuid"`
+	Timestamp int    `json:"timestamp" valid:"required"`
+	UUID      string `json:"uuid"      valid:"required,uuid"`
 }
 
 type PageContent map[string]interface{}

--- a/brochure/requests.go
+++ b/brochure/requests.go
@@ -1,0 +1,21 @@
+package brochure
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type indexPageRequest struct {
+	Page indexPageRequestPage `json:"page"`
+}
+
+type indexPageRequestPage struct {
+	Page
+}
+
+func IndexPageRequest(request http.Request) (indexPageRequest, error) {
+	decoder := json.NewDecoder(request.Body)
+	var indexPageRequest indexPageRequest
+	err := decoder.Decode(&indexPageRequest)
+	return indexPageRequest, err
+}

--- a/brochure/requests.go
+++ b/brochure/requests.go
@@ -2,20 +2,25 @@ package brochure
 
 import (
 	"encoding/json"
+	"github.com/asaskevich/govalidator"
 	"net/http"
 )
 
 type indexPageRequest struct {
-	Page indexPageRequestPage `json:"page"`
-}
-
-type indexPageRequestPage struct {
-	Page
+	Page Page `json:"page" valid:"required"`
 }
 
 func IndexPageRequest(request http.Request) (indexPageRequest, error) {
-	decoder := json.NewDecoder(request.Body)
 	var indexPageRequest indexPageRequest
-	err := decoder.Decode(&indexPageRequest)
-	return indexPageRequest, err
+
+	decoder := json.NewDecoder(request.Body)
+	if err := decoder.Decode(&indexPageRequest); err != nil {
+		return indexPageRequest, err
+	}
+
+	if valid, err := govalidator.ValidateStruct(indexPageRequest); !valid {
+		return indexPageRequest, err
+	}
+
+	return indexPageRequest, nil
 }

--- a/brochure/requests_test.go
+++ b/brochure/requests_test.go
@@ -28,6 +28,60 @@ func TestIndexPageRequest(t *testing.T) {
 	assert.Equal(t, "f5826bba-4496-4361-a061-e8b76ec0971d", req.Page.Release.UUID)
 }
 
+func TestIndexPageRequestValidationErrors(t *testing.T) {
+	_, emptyRequestErr := IndexPageRequest(createMockRequest(`{}`))
+	assert.NotNil(t, emptyRequestErr)
+
+	_, noIDErr := IndexPageRequest(createMockRequest(`{
+		"page": {
+			"release": {
+				"timestamp": 1000,
+				"uuid": "f5826bba-4496-4361-a061-e8b76ec0971d"
+			}
+		}
+	}`))
+	assert.NotNil(t, noIDErr)
+
+	_, emptyURIErr := IndexPageRequest(createMockRequest(`{
+		"page": {
+			"id": {
+				"uri": ""
+			},
+			"release": {
+				"timestamp": 1000,
+				"uuid": "f5826bba-4496-4361-a061-e8b76ec0971d"
+			}
+		}
+	}`))
+	assert.NotNil(t, emptyURIErr)
+
+	_, invalidURIErr := IndexPageRequest(createMockRequest(`{
+		"page": {
+			"id": {
+				"uri": "this wont work"
+			},
+			"release": {
+				"timestamp": 1000,
+				"uuid": "f5826bba-4496-4361-a061-e8b76ec0971d"
+			}
+		}
+	}`))
+	assert.NotNil(t, invalidURIErr)
+
+	_, invalidReleaseUUIDErr := IndexPageRequest(createMockRequest(`{
+		"page": {
+			"id": {
+				"uri": "//madetech.com/?locale=en-GB"
+			},
+			"release": {
+				"timestamp": 1000,
+				"uuid": "uh oh"
+			}
+		}
+	}`))
+	assert.NotNil(t, invalidReleaseUUIDErr)
+}
+
 func createMockRequest(jsonBody string) http.Request {
 	return http.Request{Body: ioutil.NopCloser(strings.NewReader(jsonBody))}
 }

--- a/brochure/requests_test.go
+++ b/brochure/requests_test.go
@@ -1,0 +1,33 @@
+package brochure
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIndexPageRequest(t *testing.T) {
+	req, _ := IndexPageRequest(createMockRequest(`{
+		"page": {
+			"id": {
+				"uri": "//madetech.com/?locale=en-GB"
+			},
+			"release": {
+				"timestamp": 1000,
+				"uuid": "f5826bba-4496-4361-a061-e8b76ec0971d"
+			}
+		}
+	}`))
+
+	assert.Equal(t, "madetech.com", req.Page.Id.Host)
+	assert.Equal(t, "/", req.Page.Id.Path)
+	assert.Equal(t, "en-GB", req.Page.Id.Locale)
+	assert.Equal(t, 1000, req.Page.Release.Timestamp)
+	assert.Equal(t, "f5826bba-4496-4361-a061-e8b76ec0971d", req.Page.Release.UUID)
+}
+
+func createMockRequest(jsonBody string) http.Request {
+	return http.Request{Body: ioutil.NopCloser(strings.NewReader(jsonBody))}
+}


### PR DESCRIPTION
We introduce `IndexPageRequest()` so that we can convert a JSON request body into a readily indexable struct `indexPageRequest`.

`IndexPageRequest()` is responsible for validating the `indexPageRequest` ensuring all required fields are present. In the case of validation errors, the error return value will be set.

We add tests to assert validations.