### PR TITLE
Ensure shipments are created with shipping rates

### DIFF
--- a/checkout/lib/market_town/checkout/integrations/spree/finish.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree/finish.rb
@@ -7,15 +7,7 @@ module MarketTown
         end
 
         def address_step(state)
-          state[:order].build_bill_address(transform_address(state[:billing_address]))
-          state[:order].build_ship_address(transform_address(state[:delivery_address]))
           state[:order].update_attributes!(state: :delivery)
-        end
-
-        private
-
-        def transform_address(address)
-          AddressTransformation.new.transform(address)
         end
       end
     end

--- a/checkout/lib/market_town/checkout/integrations/spree/fulfilments.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree/fulfilments.rb
@@ -8,7 +8,11 @@ module MarketTown
         end
 
         def can_fulfil_shipments?(state)
-          true
+          if state[:order].send(:ensure_available_shipping_rates) == false
+            false
+          else
+            true
+          end
         end
 
         def apply_shipment_costs(state)

--- a/checkout/lib/market_town/checkout/integrations/spree/order.rb
+++ b/checkout/lib/market_town/checkout/integrations/spree/order.rb
@@ -5,6 +5,18 @@ module MarketTown
         def has_line_items?(state)
           state[:order].line_items.any?
         end
+
+        def set_addresses(state)
+          state[:order].build_bill_address(transform_address(state[:billing_address]))
+          state[:order].build_ship_address(transform_address(state[:delivery_address]))
+          nil
+        end
+
+        private
+
+        def transform_address(address)
+          AddressTransformation.new.transform(address)
+        end
       end
     end
   end

--- a/checkout/lib/market_town/checkout/steps/address_step.rb
+++ b/checkout/lib/market_town/checkout/steps/address_step.rb
@@ -6,6 +6,7 @@ module MarketTown
     #
     # - {Contracts::UserAddressStorage#store_billing_address}
     # - {Contracts::UserAddressStorage#store_delivery_address}
+    # - {Contracts::Order#set_addresses}
     # - {Contracts::Fulfilments#propose_shipments}
     # - {Contracts::Fulfilments#can_fulfil_shipments?}
     # - {Contracts::Fulfilments#apply_shipment_costs}
@@ -18,6 +19,7 @@ module MarketTown
       steps :validate_billing_address,
             :use_billing_address_as_delivery_address,
             :validate_delivery_address,
+            :set_order_addresses,
             :store_user_addresses,
             :propose_shipments,
             :validate_shipments,
@@ -44,6 +46,14 @@ module MarketTown
       #
       def validate_delivery_address(state)
         validate_address(:delivery, state[:delivery_address])
+      end
+
+      # Sets addresses on order
+      #
+      def set_order_addresses(state)
+        deps.order.set_addresses(state)
+      rescue MissingDependency
+        add_dependency_missing_warning(state, :cannot_set_order_addresses)
       end
 
       # Tries to store user addresses

--- a/checkout/spec/checkout/integrations/solidus/spec_helper.rb
+++ b/checkout/spec/checkout/integrations/solidus/spec_helper.rb
@@ -3,3 +3,41 @@ require File.expand_path('../../../../fixtures/solidus/dummy/config/environment.
 require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 require 'spree/testing_support/factories'
+require 'spree/testing_support/order_walkthrough'
+
+# We copied the OrderWalkthrough#up_to here for Solidus as it behaves
+# differently to the Spree version of OrderWalkthrough.
+#
+# #up_to(:address) for in Solidus actually goes up to :delivery whereas
+# Spree it goes up to the :address step.
+#
+# We also customised @country assignment to look for existing country
+# rather than creating a new one so we don't have duplicate countries
+# during tests.
+#
+def order_upto_address
+  # Need to create a valid zone too...
+  @zone = FactoryGirl.create(:zone)
+  @country = Spree::Country.find_or_create_by(FactoryGirl.attributes_for(:country))
+  @state = FactoryGirl.create(:state, country: @country)
+
+  @zone.members << Spree::ZoneMember.create(zoneable: @country)
+
+  # A shipping method must exist for rates to be displayed on checkout page
+  FactoryGirl.create(:shipping_method, zones: [@zone]).tap do |sm|
+    sm.calculator.preferred_amount = 10
+    sm.calculator.preferred_currency = Spree::Config[:currency]
+    sm.calculator.save
+  end
+
+  order = Spree::Order.create!(
+    email: "spree@example.com",
+    store: Spree::Store.first || FactoryGirl.create(:store)
+  )
+
+  FactoryGirl.create(:line_item, order: order)
+  order.reload
+  order.next!
+
+  order
+end

--- a/checkout/spec/checkout/integrations/spree/spec_helper.rb
+++ b/checkout/spec/checkout/integrations/spree/spec_helper.rb
@@ -3,3 +3,8 @@ require File.expand_path('../../../../fixtures/spree/dummy/config/environment.rb
 require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 require 'spree/testing_support/factories'
+require 'spree/testing_support/order_walkthrough'
+
+def order_upto_address
+  OrderWalkthrough.up_to(:address)
+end

--- a/checkout/spec/checkout/integrations/spree_like/address_step.rb
+++ b/checkout/spec/checkout/integrations/spree_like/address_step.rb
@@ -4,7 +4,7 @@ module MarketTown::Checkout
       before(:each) { create(:country, iso: 'US', iso3: 'USA') }
 
       context 'and addresses valid' do
-        let(:order) { create(:order_with_totals) }
+        let(:order) { order_upto_address }
 
         before(:each) do
           AddressStep.new(deps).process(order: order,

--- a/checkout/spec/checkout/integrations/spree_like/address_step.rb
+++ b/checkout/spec/checkout/integrations/spree_like/address_step.rb
@@ -1,8 +1,6 @@
 module MarketTown::Checkout
   shared_examples_for 'address step using spree-like container' do
     context 'when processing address step' do
-      before(:each) { create(:country, iso: 'US', iso3: 'USA') }
-
       context 'and addresses valid' do
         let(:order) { order_upto_address }
 


### PR DESCRIPTION
In order to ensure shipments are created with shipping rates we had to move setting of address on order to Spree::Order integration. We also had to create a custom order walkthrough for Solidus to account for differences between it and Spree.

We finally implement Spree::Fulfilments#can_fulfil_shipments? to ensure this for users :)